### PR TITLE
Correcting links to new documentation website

### DIFF
--- a/book/overview/graphql/README.md
+++ b/book/overview/graphql/README.md
@@ -1,9 +1,9 @@
 # GraphQL
 
-* [Getting Started](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/getting-started.md)
-* [Pagination](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/pagination.md)
-* [Connections](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/connections.md)
-* [Errors](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/errors.md)
-* [What's Next](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/whats-next.md)
-* [Mutation](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/mutations.md)
+* [Getting Started](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started)
+* [Pagination](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/pagination)
+* [Connections](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/connections)
+* [Errors](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/errors)
+* [What's Next](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/whats-next)
+* [Mutation](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/mutations)
 

--- a/book/overview/graphql/whats-next.md
+++ b/book/overview/graphql/whats-next.md
@@ -4,7 +4,7 @@ Now you've learned how to query the AniList GraphQL Api, you should test writing
 
 You can also view our [API reference documentation](https://anilist.github.io/ApiV2-GraphQL-Docs/) for the same information without the live editor.
 
-**If you plan on adding user authentication to your application you should also read the** [**Mutation**](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/graphql/mutations.md) **and** [**OAuth**](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/oauth.md) **docs.**   
+**If you plan on adding user authentication to your application you should also read the** [**Mutation**](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/mutations) **and** [**OAuth**](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth) **docs.**   
   
   
   

--- a/book/overview/migrating-from-apiv1.md
+++ b/book/overview/migrating-from-apiv1.md
@@ -21,7 +21,7 @@ Sadly the OAuth packages used for Api v1 have been deprecated and will stop rece
 * The `api/auth/authorize` route is now `api/v2/oauth/authorize`
 * The `api/auth/access_token` route is now `api/v2/oauth/token`
 
-[View the OAuth docs page for more info about getting OAuth setup for Api v2.](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/oauth.md)
+[View the OAuth docs page for more info about getting OAuth setup for Api v2.](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth)
 
 ## Snake Case to Camel Case
 

--- a/book/overview/oauth/README.md
+++ b/book/overview/oauth/README.md
@@ -1,6 +1,6 @@
 # OAuth
 
-* [Getting Started](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/getting-started.md)
-* [Authorization Code Grant](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/oauth/authorization-code-grant.md)
-* [Implicit Grant](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/oauth/implicit-grant.md)
+* [Getting Started](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/getting-started)
+* [Authorization Code Grant](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/authorization-code-grant)
+* [Implicit Grant](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/implicit-grant)
 

--- a/book/overview/oauth/getting-started.md
+++ b/book/overview/oauth/getting-started.md
@@ -20,9 +20,9 @@ Your client name will appear to the user when asking for approval, so ensure it 
 
 Follow the guides for your grant type to learn how to request access tokens and how to use them to make authenticated requests:
 
-### [Authorization Code Grant](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/oauth/authorization-code-grant.md)
+### [Authorization Code Grant](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/authorization-code-grant)
 
-### [Implicit Grant](https://github.com/anilist/anilist-apiv2-docs/tree/e652e2f370ec3d52f21c943db7999763733b4cb2/oauth/implicit-grant.md)
+### [Implicit Grant](https://anilist.gitbook.io/anilist-apiv2-docs/overview/oauth/implicit-grant)
 
 ## Auth Pin
 


### PR DESCRIPTION
All of the links inside of the pages were still linking to the old GitHub docs, so these links should be correct and pointing to the new documentation pages