### PR TITLE
Fix broken links in resources-and-recommended-reading.md

### DIFF
--- a/book/overview/resources-and-recommended-reading.md
+++ b/book/overview/resources-and-recommended-reading.md
@@ -4,13 +4,13 @@
 
 * [GraphiQL](https://anilist.co/graphiql) - An in-browser IDE for exploring the AniList GraphQL API.
 * [API Reference Docs](https://anilist.github.io/ApiV2-GraphQL-Docs/) - The same information available in the GraphiQL sidebar, just laid out nicer.
-* [Discord](https://discord.gg/anilist) - Ask for help in the \#programming channel.
+* [Discord](https://discord.gg/TF428cr) - Ask for help in the \#programming channel.
 * [API Github Issues](https://github.com/AniList/ApiV2-GraphQL-Docs/issues) - Ask for help or report bugs.
 
 ## Tools
 
 * [Insomnia](https://insomnia.rest/)
-* [Chrome GraphQL Dev Tools Extension](https://chrome.google.com/webstore/detail/graphql-network/igbmhmnkobkjalekgiehijefpkdemocm)
+* [GraphQL Network Inspector](https://chrome.google.com/webstore/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln)
 * [ESLint GraphQL](https://github.com/apollographql/eslint-plugin-graphql)
 * [GraphQL IntelliJ Plugin](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/)
 


### PR DESCRIPTION
check [this discord message](https://discord.com/channels/210521487378087947/742415154238586940/1062765522862739516) plz

Oceanlord#0001 asked to submit a PR, so I am here now ... 

> for Discord,
I updated it with https://anilist.co 's footer's discord link.  I think it would be better to have a link like "https://anilist.co/discord" that redirects to the discord invite link.
> 
> for GraphQL extensions,
I searched with the previous one's name and it came as this one,  which is the most popular in the chrome web store too.

